### PR TITLE
Add build.sh, standard in outrigger docker repos.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+docker build -t outrigger/yeoman .


### PR DESCRIPTION
We have this in all outrigger image repos by default. By running the build.sh, it builds the local image and assigns it the same image name as one you'd pull from docker-hub. As a result you can then test the image via docker run or docker-compose commands without changing anything.

Next docker pull wipes it.