### PR TITLE
Drop node-inspector for 'production' purposes.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk update && apk upgrade && \
 RUN node -v
 RUN npm -v
 RUN echo "Yeoman Doctor will warn about our npm version being outdated. It is expected and OK."
-RUN npm install --global --silent yo node-inspector
+RUN npm install --global --silent yo
 
 # Add a yeoman user because Yeoman freaks out and runs setuid(501).
 # This was because less technical people would run Yeoman as root and cause problems.


### PR DESCRIPTION
node-inspector adds just under 4 MB to the size of the image, and shouldn't really be used for "production" images. Instead, projects can add an extending Dockerfile to their own project for global dependencies.