### PR TITLE
Add maintainer label.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:6-alpine
+LABEL maintainer "Phase2 <outrigger@phase2technology.com>"
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh curl


### PR DESCRIPTION
We should add the maintainer label to all "base" images at least to clarify that Redhat et al are not the (inherited) maintainers of record for our images.

This is the recommended replacement for the old MAINTAINER directive, per the documentation: https://docs.docker.com/engine/reference/builder/#maintainer-deprecated

I've been seeing it crop up on Docker Hub, and if it's good enough for [jessfraz](https://github.com/jessfraz/dockerfiles) it's good enough for us :)